### PR TITLE
Bugfix: fix regex mismatching empty space after sourceMappingURL issue.

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ var path = require("path");
 var async = require("async");
 var loaderUtils = require("loader-utils");
 
-var baseRegex = "\\s*[@#]\\s*sourceMappingURL\\s*=\\s*(.*)",
+var baseRegex = "\\s*[@#]\\s*sourceMappingURL\\s*=\\s*([^\\s]*)",
 	// Matches /* ... */ comments
 	regex1 = new RegExp("/\\*"+baseRegex+"\\s*\\*/"),
 	// Matches // .... comments


### PR DESCRIPTION
For now, baseRegex mismatch empty space after <url> which lead to 'Cannot find
SourceMap' problem. 

e.g.  map file name of bootstrap.css ( `/*# sourceMappingURL=bootstrap.css.map */` ) will be resolved to bootstrap.css.map<***space***>