### PR TITLE
Fix: fix the 'undefined' string in the css file issue.

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,6 +90,6 @@ module.exports = function(input, inputMap) {
 			});
 			return;
 		}
-		callback(null, input.replace(match[0], match[2]), map);
+		callback(null, input.replace(match[0], ''), map);
 	}
 }


### PR DESCRIPTION
There is an incorrect 'undefined' string in the css file after processing by
source-map-loader.

It's caused by the line 
```javascript
callback(null, input.replace(match[0], match[2]), map);
```

There are two kinds of comment format `regex1` and `regex2`. `regex1` only have one capture group so `match[2]` will be `undefined`. So maybe just replace by empty would be OK?



